### PR TITLE
Integrate connexion controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository provides a simple REST API written in Python using Flask. The API can be used for experimenting with chaos engineering techniques and for running end‑to‑end regression tests using `curl`.
 
+The endpoint functions live in [`controllers.py`](controllers.py) and are referenced from `api_spec.yaml` via `operationId` definitions. The server uses [Connexion](https://connexion.readthedocs.io/) to load the OpenAPI specification and dispatch requests to these controller functions.
+
 ## Requirements
 
 * Python 3.11+

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -6,6 +6,7 @@ paths:
   /ping:
     get:
       summary: Health check
+      operationId: controllers.ping
       responses:
         '200':
           description: Returns pong message
@@ -20,6 +21,7 @@ paths:
   /items:
     get:
       summary: List all items
+      operationId: controllers.list_items
       responses:
         '200':
           description: List of items
@@ -31,6 +33,7 @@ paths:
                   $ref: '#/components/schemas/Item'
     post:
       summary: Create a new item
+      operationId: controllers.create_item
       requestBody:
         required: true
         content:
@@ -47,6 +50,7 @@ paths:
   /items/{id}:
     get:
       summary: Get item by ID
+      operationId: controllers.get_item
       parameters:
         - in: path
           name: id
@@ -64,6 +68,7 @@ paths:
           description: Not found
     put:
       summary: Update item
+      operationId: controllers.update_item
       parameters:
         - in: path
           name: id
@@ -87,6 +92,7 @@ paths:
           description: Not found
     delete:
       summary: Delete item
+      operationId: controllers.delete_item
       parameters:
         - in: path
           name: id

--- a/controllers.py
+++ b/controllers.py
@@ -1,0 +1,40 @@
+from flask import jsonify, request, abort
+
+items = {}
+next_id = 1
+
+def ping():
+    return jsonify({'message': 'pong'})
+
+def list_items():
+    return jsonify(list(items.values()))
+
+def create_item():
+    global next_id
+    data = request.get_json(force=True)
+    if not data or 'name' not in data:
+        abort(400)
+    item = {'id': next_id, 'name': data['name']}
+    items[next_id] = item
+    next_id += 1
+    return jsonify(item), 201
+
+def get_item(id):
+    if id not in items:
+        abort(404)
+    return jsonify(items[id])
+
+def update_item(id):
+    if id not in items:
+        abort(404)
+    data = request.get_json(force=True)
+    if not data or 'name' not in data:
+        abort(400)
+    items[id]['name'] = data['name']
+    return jsonify(items[id])
+
+def delete_item(id):
+    if id not in items:
+        abort(404)
+    deleted = items.pop(id)
+    return jsonify(deleted)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask==3.0.3
+
+connexion[flask]>=3.0.0

--- a/server.py
+++ b/server.py
@@ -1,43 +1,7 @@
-from flask import Flask, jsonify, request, abort
+import connexion
 
-app = Flask(__name__)
-
-items = {}
-next_id = 1
-
-@app.route('/ping', methods=['GET'])
-def ping():
-    return jsonify({'message': 'pong'})
-
-@app.route('/items', methods=['GET', 'POST'])
-def items_route():
-    global next_id
-    if request.method == 'GET':
-        return jsonify(list(items.values()))
-    elif request.method == 'POST':
-        data = request.get_json(force=True)
-        if not data or 'name' not in data:
-            abort(400)
-        item = {'id': next_id, 'name': data['name']}
-        items[next_id] = item
-        next_id += 1
-        return jsonify(item), 201
-
-@app.route('/items/<int:item_id>', methods=['GET', 'PUT', 'DELETE'])
-def item_route(item_id):
-    if item_id not in items:
-        abort(404)
-    if request.method == 'GET':
-        return jsonify(items[item_id])
-    elif request.method == 'PUT':
-        data = request.get_json(force=True)
-        if not data or 'name' not in data:
-            abort(400)
-        items[item_id]['name'] = data['name']
-        return jsonify(items[item_id])
-    elif request.method == 'DELETE':
-        deleted = items.pop(item_id)
-        return jsonify(deleted)
+app = connexion.App(__name__, specification_dir='.')
+app.add_api('api_spec.yaml')
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add connexion to requirements
- implement controller functions in `controllers.py`
- use connexion in `server.py`
- reference controller source in README
- map OpenAPI operations to controller functions

## Testing
- `pip install -r requirements.txt`
- `python server.py &`
- `./run_e2e_tests.sh`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_6852b8e9141c83228e84dedaba1c38e9