### PR TITLE
Expand E2E coverage and validate item names

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ See [`api_spec.yaml`](api_spec.yaml) for the OpenAPI 3.0 specification of the av
 
 ## End‑to‑end tests
 
-Run the provided script after starting the server:
+Run the provided script after starting the server. The suite now exercises
+common error scenarios such as invalid input and unknown IDs:
 
 ```bash
 ./run_e2e_tests.sh

--- a/controllers.py
+++ b/controllers.py
@@ -10,11 +10,13 @@ def list_items():
     return jsonify(list(items.values()))
 
 def create_item():
+    """Create a new item with a non-empty string name."""
     global next_id
     data = request.get_json(force=True)
-    if not data or 'name' not in data:
+    name = data.get('name') if isinstance(data, dict) else None
+    if not isinstance(name, str) or not name.strip():
         abort(400)
-    item = {'id': next_id, 'name': data['name']}
+    item = {'id': next_id, 'name': name}
     items[next_id] = item
     next_id += 1
     return jsonify(item), 201
@@ -25,12 +27,14 @@ def get_item(id):
     return jsonify(items[id])
 
 def update_item(id):
+    """Update an existing item's name."""
     if id not in items:
         abort(404)
     data = request.get_json(force=True)
-    if not data or 'name' not in data:
+    name = data.get('name') if isinstance(data, dict) else None
+    if not isinstance(name, str) or not name.strip():
         abort(400)
-    items[id]['name'] = data['name']
+    items[id]['name'] = name
     return jsonify(items[id])
 
 def delete_item(id):

--- a/run_e2e_tests.sh
+++ b/run_e2e_tests.sh
@@ -2,19 +2,37 @@
 set -euo pipefail
 BASE_URL=${BASE_URL:-http://localhost:5000}
 
+check_status() {
+  expected=$1; shift
+  status=$(curl -s -o /dev/null -w "%{http_code}" "$@")
+  if [ "$status" != "$expected" ]; then
+    echo "Expected $expected but got $status" >&2
+    exit 1
+  fi
+}
+
 # Health check
 curl -fsS "$BASE_URL/ping" | grep -q 'pong'
 
 # Create item
 ITEM_ID=$(curl -fsS -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"test"}' | jq '.id')
 
+# Invalid creates
+check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":""}'
+check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":123}'
+
 # Get item
 curl -fsS "$BASE_URL/items/${ITEM_ID}" | jq -e '.name == "test"' >/dev/null
+check_status 404 "$BASE_URL/items/9999"
 
 # Update item
 curl -fsS -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated"}' | jq -e '.name == "updated"' >/dev/null
+check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":""}'
+check_status 404 -X PUT "$BASE_URL/items/9999" -H 'Content-Type: application/json' -d '{"name":"foo"}'
 
 # Delete item
 curl -fsS -X DELETE "$BASE_URL/items/${ITEM_ID}" | jq -e ".id == ${ITEM_ID}" >/dev/null
+check_status 404 "$BASE_URL/items/${ITEM_ID}"
+check_status 404 -X DELETE "$BASE_URL/items/${ITEM_ID}"
 
 echo "All E2E tests passed" >&2


### PR DESCRIPTION
## Summary
- enforce non-empty string names when creating or updating items
- cover error scenarios such as invalid input and unknown IDs in `run_e2e_tests.sh`
- mention the additional checks in the README

## Testing
- `bash -n run_e2e_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852c08bcc40832292698de236679df9