### PR TITLE
Refine docs for inventory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Sample API Server for Chaos Testing
+# Sample Inventory API Server
 
-This repository provides a simple REST API written in Python using Flask. The API can be used for experimenting with chaos engineering techniques and for running end‑to‑end regression tests using `curl`.
+This repository provides a simple REST API written in Python using Flask. The API simulates a lightweight inventory service so you can experiment with typical CRUD operations and run end‑to‑end regression tests using `curl`.
 
-The endpoint functions live in [`controllers.py`](controllers.py) and are referenced from `api_spec.yaml` via `operationId` definitions. The server uses [Connexion](https://connexion.readthedocs.io/) to load the OpenAPI specification and dispatch requests to these controller functions.
+The endpoint functions live in [`controllers.py`](controllers.py) and are referenced from `api_spec.yaml` via `operationId` definitions. The server uses [Connexion](https://connexion.readthedocs.io/) to load the OpenAPI specification and dispatch requests to these controller functions. Together they expose operations for creating, listing, updating and deleting inventory items.
 
 ## Requirements
 

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1,7 +1,11 @@
 openapi: 3.0.0
 info:
-  title: Sample API for Chaos Testing
+  title: Sample Inventory API
   version: 1.0.0
+  description: |
+    A simple service for managing inventory items. The API supports creating,
+    listing, updating and deleting items and is useful for testing typical
+    business workflows.
 paths:
   /ping:
     get:
@@ -112,6 +116,7 @@ components:
   schemas:
     Item:
       type: object
+      description: An inventory record identified by an integer ID and a name.
       properties:
         id:
           type: integer
@@ -121,6 +126,7 @@ components:
           example: example item
     ItemInput:
       type: object
+      description: Payload used when creating or updating an inventory item.
       required:
         - name
       properties:


### PR DESCRIPTION
## Summary
- rewrite README to talk about a small inventory service
- remove chaos testing references from API spec
- document item entity in OpenAPI schema

## Testing
- `bash run_e2e_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852c81361188322867305ad8adafa9b