### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+EXPOSE 5000
+CMD ["python", "server.py"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ python server.py
 
 The server listens on `http://localhost:5000` by default.
 
+## Docker
+
+Build the container image:
+
+```bash
+docker build -t inventory-api .
+```
+
+Run the image and expose port 5000:
+
+```bash
+docker run -p 5000:5000 inventory-api
+```
+
 ## API specification
 
 See [`api_spec.yaml`](api_spec.yaml) for the OpenAPI 3.0 specification of the available endpoints.


### PR DESCRIPTION
## Summary
- add a Dockerfile for container builds
- document Docker build and run commands in the README

## Testing
- `python -m py_compile server.py controllers.py`
- ❌ `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852cf724aa08322927cd4fad137aa48